### PR TITLE
refactor: OwnableBase `onlyOwner()` modifier

### DIFF
--- a/src/facets/ownable/OwnableBase.sol
+++ b/src/facets/ownable/OwnableBase.sol
@@ -6,8 +6,12 @@ import { OwnableStorage } from "./OwnableStorage.sol";
 
 abstract contract OwnableBase is IOwnableBase {
     modifier onlyOwner() {
-        if (msg.sender != _owner()) revert Ownable_CallerIsNotOwner();
+        _checkOwner();
         _;
+    }
+
+    function _checkOwner() internal view {
+        if (msg.sender != _owner()) revert Ownable_CallerIsNotOwner();
     }
 
     function _owner() internal view returns (address) {

--- a/test/facets/cut/behavior/diamondCut.t.sol
+++ b/test/facets/cut/behavior/diamondCut.t.sol
@@ -54,7 +54,6 @@ contract DiamondCut_diamondCut is DiamondCutFacetTest {
     /**
      * ------------------------ addFacet ------------------------
      */
-
     function test_OnAdd_RevertsWhen_FunctionAlreadyExists() public {
         facetCuts.push(mockFacetHelper.makeFacetCut(FacetCutAction.Add));
         diamondCut.diamondCut(facetCuts, address(0), "");
@@ -79,7 +78,6 @@ contract DiamondCut_diamondCut is DiamondCutFacetTest {
     /**
      * ------------------------ removeFacet ------------------------
      */
-
     function test_OnRemove_RevertsWhen_RemovingFromOtherFacet() public {
         address facet = address(mockFacetHelper.facet());
         bytes4[] memory selectorsToRemove = new bytes4[](1);
@@ -122,7 +120,6 @@ contract DiamondCut_diamondCut is DiamondCutFacetTest {
     /**
      * ------------------------ replaceFacet ------------------------
      */
-
     function test_OnReplace_RevertsWhen_SelectorIsZero() public {
         bytes4[] memory selectorsToReplace = new bytes4[](1);
         selectorsToReplace[0] = bytes4(0);


### PR DESCRIPTION
Refactored `onlyOwner()` to use an internal function call to require the msg.sender is the owner.  For one, the bytecode of the modifier is appended to each function it decorates, and a function call is less bytecode than a logic gate.  Second, this follows the OZ convention (found [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/01ef448981be9d20ca85f2faf6ebdf591ce409f3/contracts/access/Ownable.sol#L48-L51))